### PR TITLE
Rename callback to ready again

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -17,10 +17,10 @@ function WebSockets () {
       options = {}
     }
 
-    options.connect = options.connect || function noop () {}
+    options.ready = options.ready || function noop () {}
     const maOpts = multiaddr.toOptions()
     const conn = new SWS('ws://' + maOpts.host + ':' + maOpts.port)
-    conn.on('connect', options.connect)
+    conn.on('connect', options.ready)
     conn.getObservedAddrs = () => {
       return [multiaddr]
     }

--- a/tests/libp2p-websockets-test.js
+++ b/tests/libp2p-websockets-test.js
@@ -90,7 +90,7 @@ describe('libp2p-websockets', function () {
       const message = 'Hello World!'
 
       const conn = ws.dial(mh, {
-        connect: () => {
+        ready: () => {
           conn.send(message)
         }
       })


### PR DESCRIPTION
Oops, just noticed I should have not renamed the `ready` callback on #2, so this reverts it.